### PR TITLE
Update fe_bootstrap.html5

### DIFF
--- a/src/system/modules/bootstrap/templates/fe_bootstrap.html5
+++ b/src/system/modules/bootstrap/templates/fe_bootstrap.html5
@@ -73,8 +73,13 @@
 </div>
 <?php echo $this->mootools; ?>
 <?php if (!$this->disableCron): ?>
-
-	<script src="<?php echo TL_ASSETS_URL; ?>assets/contao/js/scheduler.js?t=<?php echo $this->cronTimeout; ?>" id="cron"></script>
+	<script>
+		<?php if ($this->layout->addJQuery): ?>
+			setTimeout(function(){jQuery.ajax("system/cron/cron.txt",{complete:function(e){var t=e.responseText||0;parseInt(t)<Math.round(+(new Date)/1e3)-<?php echo $this->cronTimeout; ?>&&jQuery.ajax("system/cron/cron.php")}})},5e3)
+		<?php else: ?>
+			setTimeout(function(){(new Request({url:"system/cron/cron.txt",onComplete:function(e){e||(e=0),parseInt(e)<Math.round(+(new Date)/1e3)-<?php echo $this->cronTimeout; ?>&&(new Request({url:"system/cron/cron.php"})).get()}})).get()},5e3)
+		<?php endif; ?>
+	</script>
 <?php endif; ?>
 
 </body>


### PR DESCRIPTION
Update fe_bootstrap.html5 to use ajaxed cron.txt/php instead of old scheduler.js (just like in default fe_page.html5, see https://github.com/contao/core/commit/654babbf4e1c59d09c258cb52b1230da1e3cf6cf#diff-343d56c4683837ed52cd8c774c460818 for 3.1)
