### PR TITLE
Enable dropdown menus without having m17Folder

### DIFF
--- a/src/Netzmacht/Bootstrap/Template/Modifier/Navigation.php
+++ b/src/Netzmacht/Bootstrap/Template/Modifier/Navigation.php
@@ -86,7 +86,7 @@ class Navigation
 
 				if($item['subitems'])
 				{
-					if($item['type'] == 'm17Folder')
+					if($item['type'] == 'm17Folder' || $item['href'] == '#')
 					{
 						if($level == 1 || $template->disableUl)
 						{
@@ -106,7 +106,7 @@ class Navigation
 					$item['toggle'] = 'class="dropdown-toggle"';
 
 
-					if($item['type'] == 'm17Folder')
+					if($item['type'] == 'm17Folder' || $item['href'] == '#')
 					{
 						if($template->level == 'level_1')
 						{


### PR DESCRIPTION
I added an href check, so if you add a site with an external redirect who points to # the navigation now renders it the same way as if the m17Folder extension is installed
