### PR TITLE
Require contao-community-alliance/composer-plugin ~2.0 now.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require":{
         "php":">=5.3.4",
         "contao/core":">=3.1,<3.3",
+        "contao-community-alliance/composer-plugin":"~2.0",
         "menatwork/contao-multicolumnwizard":"~3.2",
         "bit3/contao-theme-plus":"~4.0",
         "bit3/contao-meta-palettes":">=1.4.2",


### PR DESCRIPTION
Require the `composer-plugin`, every `contao-module` should require the plugin.
